### PR TITLE
Fix serialization issue with primitive types

### DIFF
--- a/src/main/java/net/adambruce/ResultPane.java
+++ b/src/main/java/net/adambruce/ResultPane.java
@@ -54,9 +54,8 @@ public class ResultPane extends VBox {
         }
 
         try {
-            String pathResult = JsonPath.read(json, path).toString();
-            Object jacksonObject = new ObjectMapper().readValue(pathResult, Object.class);
-            return new ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(jacksonObject);
+            return new ObjectMapper().writerWithDefaultPrettyPrinter()
+                    .writeValueAsString(JsonPath.read(json, path));
         } catch (Exception ex) {
             isResultError.set(true);
             return ex.getMessage();


### PR DESCRIPTION
This PR fixes an issue where casting a JsonPath object to a string produced Java style object syntax and not JSON style.

This seemed to work fine for objects which were turned into arrays of maps, however Jackson ran into errors for strings, and possibly other primitive types, as Java does not quote these types in `toString`.